### PR TITLE
Implement Custom Report dialog

### DIFF
--- a/src/components/reports/CustomReportDialog.tsx
+++ b/src/components/reports/CustomReportDialog.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { useForm } from "react-hook-form";
+import { toast } from "@/hooks/use-toast";
+import { FileText } from "lucide-react";
+
+export interface CustomReportData {
+  name: string;
+  type: string;
+  description: string;
+}
+
+interface CustomReportDialogProps {
+  onCreate: (data: CustomReportData) => void;
+}
+
+export const CustomReportDialog = ({ onCreate }: CustomReportDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const form = useForm<CustomReportData>({
+    defaultValues: { name: "", type: "PDF", description: "" },
+  });
+
+  const onSubmit = (data: CustomReportData) => {
+    onCreate(data);
+    toast({
+      title: "Custom Report Created",
+      description: `${data.name} has been generated`,
+    });
+    form.reset({ name: "", type: "PDF", description: "" });
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button className="bg-blue-600 hover:bg-blue-700">
+          <FileText className="h-4 w-4 mr-2" />
+          Custom Report
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create Custom Report</DialogTitle>
+          <DialogDescription>
+            Specify the details for your custom report.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Report Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Monthly Performance" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="PDF">PDF</SelectItem>
+                      <SelectItem value="Excel">Excel</SelectItem>
+                      <SelectItem value="CSV">CSV</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Brief description" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit">Create</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -5,11 +5,12 @@ import { Sidebar } from "@/components/navigation/Sidebar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Download, FileText, BarChart3, PieChart, TrendingUp } from "lucide-react";
+import { CustomReportDialog, CustomReportData } from "@/components/reports/CustomReportDialog";
 
 const Reports = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
-  const reports = [
+  const [reports, setReports] = useState([
     {
       id: 1,
       name: "Project Progress Summary",
@@ -58,7 +59,21 @@ const Reports = () => {
       lastGenerated: "2024-06-14",
       icon: FileText,
     },
-  ];
+  ]);
+
+  const handleCreateReport = (data: CustomReportData) => {
+    setReports((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        name: data.name,
+        description: data.description,
+        type: data.type,
+        lastGenerated: new Date().toISOString(),
+        icon: FileText,
+      },
+    ]);
+  };
 
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-900">
@@ -78,10 +93,7 @@ const Reports = () => {
                   Generate and download comprehensive project reports.
                 </p>
               </div>
-              <Button className="bg-blue-600 hover:bg-blue-700">
-                <FileText className="h-4 w-4 mr-2" />
-                Custom Report
-              </Button>
+              <CustomReportDialog onCreate={handleCreateReport} />
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- add a new `CustomReportDialog` component with a form for report name, type and description
- integrate dialog in `Reports` page and keep created custom reports in local state
- hook the "Custom Report" button so it opens the dialog and adds new reports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851502163dc8333ad5bb21586c53fed