### PR TITLE
Add async tutorial video loader

### DIFF
--- a/src/components/tutorial/VideoLibrary.tsx
+++ b/src/components/tutorial/VideoLibrary.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Search, Play, Clock } from "lucide-react";
 import { TutorialVideo } from "@/types/tutorial";
-import { tutorialService } from "@/services/tutorialService";
+import { getVideos } from "@/services/tutorialService";
 
 interface VideoLibraryProps {
   isOpen: boolean;
@@ -22,7 +22,7 @@ export const VideoLibrary = ({ isOpen, onClose, onVideoSelect }: VideoLibraryPro
   useEffect(() => {
     const load = async () => {
       setLoading(true);
-      const result = await tutorialService.getVideos();
+      const result = await getVideos();
       setVideos(result);
       setLoading(false);
     };

--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Play, Clock, Search, BookOpen, Upload } from "lucide-react";
-import { tutorialService } from "@/services/tutorialService";
+import { getVideos } from "@/services/tutorialService";
 import { TutorialVideo } from "@/types/tutorial";
 import { toast } from "@/hooks/use-toast";
 
@@ -31,7 +31,7 @@ const Tutorial = () => {
   useEffect(() => {
     const load = async () => {
       setLoading(true);
-      const result = await tutorialService.getVideos();
+      const result = await getVideos();
       setVideos(result);
       setLoading(false);
     };

--- a/src/services/tutorialService.ts
+++ b/src/services/tutorialService.ts
@@ -61,3 +61,7 @@ class TutorialService {
 }
 
 export const tutorialService = new TutorialService();
+
+export async function getVideos(): Promise<TutorialVideo[]> {
+  return tutorialService.getAllVideos();
+}


### PR DESCRIPTION
## Summary
- provide an asynchronous `getVideos` function in the tutorial service
- use `getVideos` in Tutorial page and VideoLibrary component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851a961c39c83339806945445e0b3e2