### PR TITLE
Add env example and update setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment configuration for BuildPro Sync Connect
+# Copy this file to ".env" and replace the placeholders with your actual values.
+
+# URL of the WebSocket server used by the application
+VITE_WS_URL=ws://your-websocket-url
+
+# Add any additional API URLs below
+# VITE_API_URL=http://your-api-url

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Create an `.env` file from the provided example and update it as needed.
+cp .env.example .env
+# Be sure to set `VITE_WS_URL` and any other API URLs in this new file.
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for websocket and API URLs
- document env setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851a96dbde48333ad1dabdb3c3091a2