### PR TITLE
Implement global search context with dropdown results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TutorialProvider } from "@/components/tutorial/TutorialProvider";
 import { CollaborationProvider } from "@/components/collaboration/CollaborationProvider";
+import { SearchProvider } from "@/components/search/SearchProvider";
 import Index from "./pages/Index";
 import Projects from "./pages/Projects";
 import Sites from "./pages/Sites";
@@ -26,12 +27,13 @@ const App = () => (
     <TooltipProvider>
       <CollaborationProvider>
         <TutorialProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/projects" element={<Projects />} />
+          <SearchProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/projects" element={<Projects />} />
               <Route path="/sites" element={<Sites />} />
               <Route path="/workforce" element={<Workforce />} />
               <Route path="/equipment" element={<Equipment />} />
@@ -45,6 +47,7 @@ const App = () => (
               <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>
+          </SearchProvider>
         </TutorialProvider>
       </CollaborationProvider>
     </TooltipProvider>

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,7 +1,9 @@
 
+import { useState } from "react";
 import { Bell, Menu, Search, Settings, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useSearchContext } from "@/components/search/SearchProvider";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +18,9 @@ interface DashboardHeaderProps {
 }
 
 export const DashboardHeader = ({ onMenuClick }: DashboardHeaderProps) => {
+  const { query, setQuery, results } = useSearchContext();
+  const [showResults, setShowResults] = useState(false);
+
   return (
     <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
       <div className="flex items-center justify-between px-6 py-4">
@@ -34,7 +39,28 @@ export const DashboardHeader = ({ onMenuClick }: DashboardHeaderProps) => {
             <Input
               placeholder="Search projects, sites, tasks..."
               className="pl-10 w-80 bg-gray-50 dark:bg-gray-700"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onFocus={() => setShowResults(true)}
+              onBlur={() => setTimeout(() => setShowResults(false), 100)}
             />
+            {showResults && query !== "" && (
+              <div className="absolute left-0 right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded shadow-lg z-50 max-h-60 overflow-y-auto text-sm">
+                {results.length === 0 && (
+                  <div className="px-3 py-2 text-gray-500">No results found</div>
+                )}
+                {results.map((r) => (
+                  <a
+                    key={`${r.type}-${r.id}`}
+                    href={r.path}
+                    className="block px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                  >
+                    <span className="font-medium">{r.name}</span>
+                    <span className="ml-2 text-gray-500">{r.type}</span>
+                  </a>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/search/SearchProvider.tsx
+++ b/src/components/search/SearchProvider.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext } from "react";
+import { useSearch } from "@/hooks/useSearch";
+
+const SearchContext = createContext<ReturnType<typeof useSearch> | undefined>(undefined);
+
+export const useSearchContext = () => {
+  const context = useContext(SearchContext);
+  if (!context) {
+    throw new Error("useSearchContext must be used within a SearchProvider");
+  }
+  return context;
+};
+
+interface SearchProviderProps {
+  children: React.ReactNode;
+}
+
+export const SearchProvider = ({ children }: SearchProviderProps) => {
+  const search = useSearch();
+  return <SearchContext.Provider value={search}>{children}</SearchContext.Provider>;
+};

--- a/src/hooks/useSearch.tsx
+++ b/src/hooks/useSearch.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect } from "react";
+import { projects } from "@/data/projects";
+import { sites } from "@/data/sites";
+import { equipment } from "@/data/equipment";
+import { documents } from "@/data/documents";
+import { incidents } from "@/data/safety";
+import { reports } from "@/data/reports";
+import { timesheets } from "@/data/timesheets";
+
+export interface SearchResult {
+  id: string | number;
+  type: string;
+  name: string;
+  path: string;
+}
+
+export const useSearch = () => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+
+  useEffect(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      setResults([]);
+      return;
+    }
+
+    const res: SearchResult[] = [];
+
+    projects.forEach(p => {
+      if (p.name.toLowerCase().includes(q) || p.client.toLowerCase().includes(q)) {
+        res.push({ id: p.id, type: "Project", name: p.name, path: "/projects" });
+      }
+    });
+
+    sites.forEach(s => {
+      if (s.name.toLowerCase().includes(q) || s.project.toLowerCase().includes(q)) {
+        res.push({ id: s.id, type: "Site", name: s.name, path: "/sites" });
+      }
+    });
+
+    equipment.forEach(e => {
+      if (e.name.toLowerCase().includes(q) || e.type.toLowerCase().includes(q)) {
+        res.push({ id: e.id, type: "Equipment", name: e.name, path: "/equipment" });
+      }
+    });
+
+    documents.forEach(d => {
+      if (d.name.toLowerCase().includes(q)) {
+        res.push({ id: d.id, type: "Document", name: d.name, path: "/documents" });
+      }
+    });
+
+    incidents.forEach(i => {
+      if (i.title.toLowerCase().includes(q)) {
+        res.push({ id: i.id, type: "Incident", name: i.title, path: "/safety" });
+      }
+    });
+
+    reports.forEach(r => {
+      if (r.name.toLowerCase().includes(q) || r.description.toLowerCase().includes(q)) {
+        res.push({ id: r.id, type: "Report", name: r.name, path: "/reports" });
+      }
+    });
+
+    timesheets.forEach(t => {
+      if (t.worker.toLowerCase().includes(q) || t.task.toLowerCase().includes(q)) {
+        res.push({ id: t.id, type: "Timesheet", name: `${t.worker} - ${t.task}`, path: "/timesheets" });
+      }
+    });
+
+    setResults(res);
+  }, [query]);
+
+  return { query, setQuery, results };
+};


### PR DESCRIPTION
## Summary
- add a `useSearch` hook for cross-resource searching
- provide a `SearchProvider` context
- integrate the provider into `App`
- connect the dashboard header input to the search context and show dropdown results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851a9625a348333ab52134cdadd7e31