### PR TITLE
Add project API and integrate React Query

### DIFF
--- a/src/components/projects/NewProjectDialog.tsx
+++ b/src/components/projects/NewProjectDialog.tsx
@@ -1,5 +1,8 @@
 
 import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createProject } from "@/services/projectApi";
+import { Project } from "@/types/project";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -64,12 +67,14 @@ const formSchema = z.object({
   status: z.enum(["planned", "active", "closed"]),
 });
 
-interface NewProjectDialogProps {
-  onProjectCreate: (project: any) => void;
-}
-
-export const NewProjectDialog = ({ onProjectCreate }: NewProjectDialogProps) => {
+export const NewProjectDialog = () => {
   const [open, setOpen] = useState(false);
+
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: createProject,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["projects"] }),
+  });
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -84,7 +89,7 @@ export const NewProjectDialog = ({ onProjectCreate }: NewProjectDialogProps) => 
   });
 
   function onSubmit(values: z.infer<typeof formSchema>) {
-    const newProject = {
+    const newProject: Project = {
       id: Date.now(), // Simple ID generation for demo
       name: values.name,
       client: values.client,
@@ -99,7 +104,7 @@ export const NewProjectDialog = ({ onProjectCreate }: NewProjectDialogProps) => 
       description: values.description,
     };
 
-    onProjectCreate(newProject);
+    mutation.mutate(newProject);
     form.reset();
     setOpen(false);
   }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,5 +1,8 @@
 
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { listProjects } from "@/services/projectApi";
+import { Project } from "@/types/project";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { Sidebar } from "@/components/navigation/Sidebar";
 import { ProjectsList } from "@/components/projects/ProjectsList";
@@ -9,15 +12,16 @@ import { ProjectsFilters } from "@/components/projects/ProjectsFilters";
 import { ProjectCard } from "@/components/projects/ProjectCard";
 import { ProjectDetailPanel } from "@/components/projects/ProjectDetailPanel";
 import { NewProjectDialog } from "@/components/projects/NewProjectDialog";
-import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, Grid3X3, List, BarChart3 } from "lucide-react";
-import { projects as initialProjects } from "@/data/projects";
+import { Grid3X3, List, BarChart3 } from "lucide-react";
 
 const Projects = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [selectedProject, setSelectedProject] = useState<typeof initialProjects[0] | null>(null);
-  const [projects, setProjects] = useState(initialProjects);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const { data: projects = [], isLoading } = useQuery({
+    queryKey: ["projects"],
+    queryFn: listProjects,
+  });
   
   // Filter states
   const [searchTerm, setSearchTerm] = useState("");
@@ -50,9 +54,9 @@ const Projects = () => {
     setStartDateTo(undefined);
   };
 
-  const handleProjectCreate = (newProject: any) => {
-    setProjects(prev => [...prev, newProject]);
-  };
+  if (isLoading) {
+    return <div className="p-4">Loading...</div>;
+  }
 
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-900">
@@ -72,7 +76,7 @@ const Projects = () => {
                   Manage your construction projects and track progress.
                 </p>
               </div>
-              <NewProjectDialog onProjectCreate={handleProjectCreate} />
+              <NewProjectDialog />
             </div>
 
             {/* Filters */}

--- a/src/services/projectApi.ts
+++ b/src/services/projectApi.ts
@@ -1,0 +1,27 @@
+import { Project } from '@/types/project';
+import { projects as mockProjects } from '@/data/projects';
+
+let projects: Project[] = [...mockProjects];
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function listProjects(): Promise<Project[]> {
+  await delay(100);
+  return projects;
+}
+
+export async function createProject(project: Project): Promise<Project> {
+  await delay(100);
+  projects.push(project);
+  return project;
+}
+
+export async function updateProject(id: number, data: Partial<Project>): Promise<Project> {
+  await delay(100);
+  const index = projects.findIndex((p) => p.id === id);
+  if (index === -1) throw new Error('Project not found');
+  projects[index] = { ...projects[index], ...data };
+  return projects[index];
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,14 @@
+export interface Project {
+  id: number;
+  name: string;
+  client: string;
+  progress: number;
+  status: 'planned' | 'active' | 'closed';
+  sites: number;
+  startDate: string;
+  endDate: string;
+  budget: string;
+  teamSize: number;
+  location: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- add `Project` type definition
- expose project API with async CRUD helpers
- load projects via React Query in pages
- create projects using React Query mutation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9643e08833382385feb00c0a02a