### PR TITLE
Add video upload endpoint and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -59,7 +60,10 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const multer = require('multer');
+const cors = require('cors');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+app.use(cors());
+
+const uploadDir = path.join(__dirname, 'public', 'uploads');
+fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const name = Date.now() + '-' + Math.round(Math.random() * 1e9) + ext;
+    cb(null, name);
+  }
+});
+const upload = multer({ storage });
+
+app.use('/uploads', express.static(uploadDir));
+
+app.post('/api/upload', upload.single('video'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  res.json({ id: req.file.filename, url: `/uploads/${req.file.filename}` });
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Upload server running on port ${PORT}`);
+});

--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -12,6 +12,7 @@ import { Play, Clock, Search, BookOpen, Upload } from "lucide-react";
 import { tutorialService } from "@/services/tutorialService";
 import { TutorialVideo } from "@/types/tutorial";
 import { toast } from "@/hooks/use-toast";
+import { Progress } from "@/components/ui/progress";
 
 const Tutorial = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -27,6 +28,7 @@ const Tutorial = () => {
 
   const [videos, setVideos] = useState<TutorialVideo[]>([]);
   const [loading, setLoading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -59,14 +61,21 @@ const Tutorial = () => {
     openVideo(video.id);
   };
 
-  const handleVideoUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleVideoUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) {
-      // For now, just show a toast message
-      toast({
-        title: "Video Upload",
-        description: `Selected: ${file.name}. Upload functionality coming soon!`,
-      });
+    if (!file) return;
+    setUploadProgress(0);
+    try {
+      const video = await tutorialService.uploadVideo(file, setUploadProgress);
+      toast({ title: "Upload complete", description: `${file.name} uploaded` });
+      const result = await tutorialService.getVideos();
+      setVideos(result);
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Upload failed", variant: "destructive" });
+    } finally {
+      setUploadProgress(null);
+      event.target.value = "";
     }
   };
 
@@ -87,7 +96,7 @@ const Tutorial = () => {
                     Tutorial Library
                   </h1>
                 </div>
-                <div>
+                <div className="space-y-2">
                   <input
                     type="file"
                     accept="video/*"
@@ -102,6 +111,9 @@ const Tutorial = () => {
                     <Upload className="h-4 w-4 mr-2" />
                     Upload Video
                   </Button>
+                  {uploadProgress !== null && (
+                    <Progress value={uploadProgress} />
+                  )}
                 </div>
               </div>
               <p className="text-gray-600 dark:text-gray-400">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": "http://localhost:3001",
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- add Express server with `/api/upload` endpoint
- update vite proxy to forward API requests
- extend tutorialService with upload and getVideos helpers
- show upload progress in Tutorial page
- add new dependencies for server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a96c193c83339108ac45ab992db2