### PR TITLE
Add PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#ffffff" />
     <title>BuildPro - Construction Project & Workforce Management</title>
     <meta name="description" content="Multi-tenant construction project management platform with real-time collaboration, workforce tracking, and comprehensive reporting." />
     <meta name="author" content="BuildPro Team" />

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vite-plugin-pwa": "^0.18.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { TutorialProvider } from "@/components/tutorial/TutorialProvider";
 import { CollaborationProvider } from "@/components/collaboration/CollaborationProvider";
+import InstallPrompt from "@/components/InstallPrompt";
 import Index from "./pages/Index";
 import Projects from "./pages/Projects";
 import Sites from "./pages/Sites";
@@ -28,6 +29,7 @@ const App = () => (
         <TutorialProvider>
           <Toaster />
           <Sonner />
+          <InstallPrompt />
           <BrowserRouter>
             <Routes>
               <Route path="/" element={<Index />} />

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+const InstallPrompt = () => {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handler = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault();
+      setPromptEvent(e);
+    };
+    window.addEventListener("beforeinstallprompt", handler as EventListener);
+    return () => window.removeEventListener("beforeinstallprompt", handler as EventListener);
+  }, []);
+
+  if (!promptEvent) return null;
+
+  const promptToInstall = () => {
+    promptEvent.prompt();
+    setPromptEvent(null);
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-white p-4 shadow-lg rounded">
+      <p className="mb-2">Install this app for a better experience.</p>
+      <button
+        className="px-3 py-1 rounded bg-blue-600 text-white"
+        onClick={promptToInstall}
+      >
+        Install
+      </button>
+    </div>
+  );
+};
+
+export default InstallPrompt;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { registerSW } from 'virtual:pwa-register'
+
+registerSW({ immediate: true })
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/types/pwa.d.ts
+++ b/src/types/pwa.d.ts
@@ -1,0 +1,6 @@
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+export {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
+import { VitePWA } from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -13,6 +14,47 @@ export default defineConfig(({ mode }) => ({
     react(),
     mode === 'development' &&
     componentTagger(),
+    VitePWA({
+      registerType: 'prompt',
+      includeAssets: ['favicon.ico', 'robots.txt'],
+      manifest: {
+        name: 'BuildPro Sync Connect',
+        short_name: 'BuildPro',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#ffffff',
+        icons: [
+          {
+            src: '/placeholder.svg',
+            sizes: 'any',
+            type: 'image/svg+xml',
+          },
+        ],
+      },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) => ['style', 'script', 'image', 'font'].includes(request.destination),
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'assets-cache',
+              expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 * 7 },
+            },
+          },
+          {
+            urlPattern: /\/api\/.*$/, 
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-cache',
+              networkTimeoutSeconds: 10,
+              expiration: { maxEntries: 30, maxAgeSeconds: 60 * 60 },
+              cacheableResponse: { statuses: [0, 200] },
+            },
+          },
+        ],
+      },
+    }),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure `vite-plugin-pwa` with asset/API caching
- register service worker and add install prompt component
- include PWA manifest and icons
- remove binary icons and use placeholder SVG

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a97019f483339f092f03e175ea86